### PR TITLE
Fixes ISO output in payload

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -74,7 +74,7 @@ class Service extends Component
             
             'orderNumber' => $order->id,
             'orderId' => $order->id,
-            'orderCurrencyISO' => $currency->iso,
+            'orderCurrencyISO' => (string)$currency,
             'orderTotalPrice' => $order->totalPrice,
             'orderSource' => 'web',
             'source' => 'web',

--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -74,7 +74,7 @@ class Service extends Component
             
             'orderNumber' => $order->id,
             'orderId' => $order->id,
-            'orderCurrencyISO' => $currency,
+            'orderCurrencyISO' => $currency->iso,
             'orderTotalPrice' => $order->totalPrice,
             'orderSource' => 'web',
             'source' => 'web',


### PR DESCRIPTION
Stamped API is expecting a string for `orderCurrencyISO`, but `$currency` now returns an array. This change seems to have been [introduced fairly recently](https://github.com/craftcms/commerce/commit/d6b727a7b6807e8ed77acdeec3137afd1284c7b8#diff-935d25d7fd148ad0163fc3def8ea18585c851b02118a3d4750b4641b08886f15) in commerce.